### PR TITLE
fix: fanout byte fix

### DIFF
--- a/src/main/java/org/fanout/pubcontrol/PubControlClient.java
+++ b/src/main/java/org/fanout/pubcontrol/PubControlClient.java
@@ -7,6 +7,7 @@
 
 package org.fanout.pubcontrol;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.locks.*;
 import java.util.*;
 import java.io.UnsupportedEncodingException;
@@ -251,6 +252,7 @@ public class PubControlClient implements Runnable {
         URLConnection connection = null;
         int responseCode = 0;
         StringBuilder response = new StringBuilder();
+        byte[] body = jsonContent.getBytes(StandardCharsets.UTF_8);
         try {
             connection = url.openConnection();
             if (connection instanceof HttpURLConnection)
@@ -262,13 +264,15 @@ public class PubControlClient implements Runnable {
             connection.setRequestProperty("Content-Type",
                     "application/json");
             connection.setRequestProperty("Content-Length",
-                    Integer.toString(jsonContent.getBytes().length));
+                    Integer.toString(body.length));
             connection.setUseCaches(false);
             connection.setDoOutput(true);
+
             DataOutputStream dataOutputStream = new DataOutputStream (
             connection.getOutputStream());
-            dataOutputStream.writeBytes(jsonContent);
+            dataOutputStream.write(body);
             dataOutputStream.close();
+
             InputStream inputStream = connection.getInputStream();
             BufferedReader bufferedReader = new BufferedReader(
                     new InputStreamReader(inputStream));


### PR DESCRIPTION
## Problem
- Fastly returns a 400 due to `writeBytes` not supporting non-ascii characters:
- The content length header was appropriately handled via bytes but `writeBytes` ignores high-order eight bits of the string:
  - https://docs.oracle.com/javase/8/docs/api/java/io/DataOutput.html

> Writes a string to the output stream. For every character in the string s, taken in order, one byte is written to the output stream. If s is null, a NullPointerException is thrown.
> If s.length is zero, then no bytes are written. Otherwise, the character s[0] is written first, then s[1], and so on; the last character written is s[s.length-1]. For each character, one byte is written, the low-order byte, in exactly the manner of the writeByte method . The high-order eight bits of each character in the string are ignored.


## Fix
- read bytes only once
- use `write` instead of `writeBytes ` in `DataOutputStream`